### PR TITLE
reloading CA certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN CGO_ENABLED=0 make PREFIX=/go clean binaries && file ./bin/registry | grep "
 FROM alpine
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
 COPY --from=build /go/src/github.com/docker/distribution/bin/registry /bin/registry
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000
 ENTRYPOINT ["registry"]


### PR DESCRIPTION
The existing image this Docker file references has expired CA certs for digicert making S3 backed registry impossible.

This change reloads CERTS in the docker file to be persisted across builds.